### PR TITLE
Corrected default output directory name.

### DIFF
--- a/replacer/options.py
+++ b/replacer/options.py
@@ -18,7 +18,7 @@ if EXT_NAME is None or EXT_NAME == "":
 
 EXT_NAME_LOWER = EXT_NAME.lower().replace(' ', '_')
 
-defaultOutputDirectory = os.path.join('outputs', EXT_NAME_LOWER)
+defaultOutputDirectory = os.path.join('output', EXT_NAME_LOWER)
 
 
 def getSaveDir():


### PR DESCRIPTION
The extension was creating an additional directory at stable-diffusion-webui root called outputs while the default in the webui is output. 
Is now same as the webui default and no longer creates an additional directory at webui root.